### PR TITLE
Missing break in two case statements caused link between bias and range.

### DIFF
--- a/plugins/si-d1/SiD1Ui.cxx
+++ b/plugins/si-d1/SiD1Ui.cxx
@@ -85,6 +85,7 @@ SiD1Ui::SiD1Ui()
 			break;
 			case SiD1Plugin::paramBias:
 			biasKnob->setValue(value);
+			break;
 			case SiD1Plugin::paramDistance:
 			distanceKnob->setValue(value);
 			break;


### PR DESCRIPTION
Added necessary break statements.
